### PR TITLE
Run tasks asynchronously controlled by leases

### DIFF
--- a/src/main/java/com/github/ikhoury/consumer/PollingRoutine.java
+++ b/src/main/java/com/github/ikhoury/consumer/PollingRoutine.java
@@ -16,7 +16,7 @@ import static com.github.ikhoury.util.RandomOutcome.randomBooleanOutcome;
  * to increase throughput. If there are not enough items in the queue to justify the heavy continuous batch polling,
  * the routine switches back to single polling.
  */
-class PollingRoutine {
+public class PollingRoutine {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PollingRoutine.class);
     private static final int MINIMUM_BATCH_SIZE = 10;
@@ -33,7 +33,7 @@ class PollingRoutine {
         this.batchSize = batchSize;
     }
 
-    void doPoll() {
+    public void doPoll() {
         String queue = subscription.getQueue();
 
         if (shouldBatchPoll) {
@@ -46,7 +46,7 @@ class PollingRoutine {
         }
     }
 
-    String getWorkQueue() {
+    public String getWorkQueue() {
         return subscription.getQueue();
     }
 

--- a/src/main/java/com/github/ikhoury/consumer/PollingThread.java
+++ b/src/main/java/com/github/ikhoury/consumer/PollingThread.java
@@ -56,7 +56,6 @@ class PollingThread {
             while (!Thread.interrupted()) {
                 Lease lease = leaseBroker.acquireLeaseFor(routine);
                 leaseRunner.run(lease);
-                leaseBroker.returnLease(lease);
             }
 
             LOGGER.debug("Closed subscription for {}", queue);

--- a/src/main/java/com/github/ikhoury/consumer/SubscriptionManager.java
+++ b/src/main/java/com/github/ikhoury/consumer/SubscriptionManager.java
@@ -9,7 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.Executors;
+
+import static java.util.concurrent.Executors.newCachedThreadPool;
 
 /**
  * This class hold all subscriptions that need to be run for data processing.
@@ -33,7 +34,7 @@ public class SubscriptionManager {
         this.subscriptions = subscriptions;
         this.pollingThreads = new ArrayList<>(subscriptions.size());
         this.leaseBroker = new LeaseBroker(subscriptions.size());
-        this.leaseRunner = new LeaseRunner(Executors.newCachedThreadPool());
+        this.leaseRunner = new LeaseRunner(leaseBroker, newCachedThreadPool());
     }
 
     public void activateSubscriptions() {

--- a/src/main/java/com/github/ikhoury/lease/Lease.java
+++ b/src/main/java/com/github/ikhoury/lease/Lease.java
@@ -1,0 +1,20 @@
+package com.github.ikhoury.lease;
+
+public class Lease {
+
+    private final String name;
+    private final Runnable task;
+
+    Lease(String name, Runnable task) {
+        this.task = task;
+        this.name = name;
+    }
+
+    public Runnable getTask() {
+        return task;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
@@ -1,0 +1,41 @@
+package com.github.ikhoury.lease;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * This class hands out leases to be run in a LeaseRunner. Only a specified number of leases
+ * can be handed out. A lease owner should return the lease after running for it to be reused.
+ */
+public class LeaseBroker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaseBroker.class);
+
+    private final Semaphore leaseStore;
+
+    public LeaseBroker(int maxActiveLeases) {
+        this.leaseStore = new Semaphore(maxActiveLeases);
+    }
+
+    /**
+     * This method guarantees that the caller will return with a lease.
+     * If no lease is available then the caller will wait indefinitely for one.
+     *
+     * @param task The task that will be run by the LeaseRunner
+     * @param name Description for the lease
+     * @return A Lease for the task
+     */
+    public Lease acquireLeaseFor(Runnable task, String name) {
+        leaseStore.acquireUninterruptibly();
+
+        LOGGER.info("Acquired a lease for {}, {} estimated lease(s) left", name, leaseStore.availablePermits());
+        return new Lease(name, task);
+    }
+
+    public void returnLease(Lease lease) {
+        leaseStore.release();
+        LOGGER.info("Released a lease for {}", lease.getName());
+    }
+}

--- a/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
@@ -35,7 +35,7 @@ public class LeaseBroker {
         return new Lease(name, routine::doPoll);
     }
 
-    public void returnLease(Lease lease) {
+    void returnLease(Lease lease) {
         leaseStore.release();
         LOGGER.info("Released a lease for {}", lease.getName());
     }

--- a/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
@@ -1,5 +1,6 @@
 package com.github.ikhoury.lease;
 
+import com.github.ikhoury.consumer.PollingRoutine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,15 +24,15 @@ public class LeaseBroker {
      * This method guarantees that the caller will return with a lease.
      * If no lease is available then the caller will wait indefinitely for one.
      *
-     * @param task The task that will be run by the LeaseRunner
-     * @param name Description for the lease
+     * @param routine The routine that will be run by the LeaseRunner
      * @return A Lease for the task
      */
-    public Lease acquireLeaseFor(Runnable task, String name) {
+    public Lease acquireLeaseFor(PollingRoutine routine) {
         leaseStore.acquireUninterruptibly();
 
-        LOGGER.info("Acquired a lease for {}, {} estimated lease(s) left", name, leaseStore.availablePermits());
-        return new Lease(name, task);
+        String name = routine.getWorkQueue();
+        LOGGER.info("Acquired a lease for {}, {} estimated lease(s) left", routine.getWorkQueue(), leaseStore.availablePermits());
+        return new Lease(name, routine::doPoll);
     }
 
     public void returnLease(Lease lease) {

--- a/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 
 /**
  * Runs leases asynchronously.
@@ -13,10 +12,14 @@ public class LeaseRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LeaseRunner.class);
 
-    private static final Executor EXECUTOR = Executors.newCachedThreadPool();
+    private final Executor executor;
 
-    public static void run(Lease lease) {
+    public LeaseRunner(Executor executor) {
+        this.executor = executor;
+    }
+
+    public void run(Lease lease) {
         LOGGER.info("Running lease for {}", lease.getName());
-        EXECUTOR.execute(lease.getTask());
+        executor.execute(lease.getTask());
     }
 }

--- a/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
@@ -13,13 +13,23 @@ public class LeaseRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(LeaseRunner.class);
 
     private final Executor executor;
+    private final LeaseBroker leaseBroker;
 
-    public LeaseRunner(Executor executor) {
+    public LeaseRunner(LeaseBroker leaseBroker, Executor executor) {
         this.executor = executor;
+        this.leaseBroker = leaseBroker;
     }
 
     public void run(Lease lease) {
         LOGGER.info("Running lease for {}", lease.getName());
-        executor.execute(lease.getTask());
+        executor.execute(() -> {
+            try {
+                lease.getTask().run();
+            } catch (Throwable throwable) {
+                LOGGER.error("Failed to run lease for {}", lease.getName(), throwable);
+            } finally {
+                leaseBroker.returnLease(lease);
+            }
+        });
     }
 }

--- a/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseRunner.java
@@ -1,0 +1,22 @@
+package com.github.ikhoury.lease;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+/**
+ * Runs leases asynchronously.
+ */
+public class LeaseRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaseRunner.class);
+
+    private static final Executor EXECUTOR = Executors.newCachedThreadPool();
+
+    public static void run(Lease lease) {
+        LOGGER.info("Running lease for {}", lease.getName());
+        EXECUTOR.execute(lease.getTask());
+    }
+}

--- a/src/test/java/com/github/ikhoury/consumer/PollingThreadTest.java
+++ b/src/test/java/com/github/ikhoury/consumer/PollingThreadTest.java
@@ -33,20 +33,13 @@ public class PollingThreadTest {
 
     @Test
     public void onlyRunsRoutineWhenStarted() {
+        verifyZeroInteractions(leaseRunner);
+
         pollingThread.start();
         verify(leaseRunner, timeout(SHORT_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
 
         pollingThread.stop();
         reset(leaseRunner);
         verifyZeroInteractions(leaseRunner);
-    }
-
-    @Test
-    public void returnsLeaseAfterRunningRoutine() {
-        pollingThread.start();
-        verify(leaseRunner, timeout(SHORT_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
-
-        pollingThread.stop();
-        verify(leaseBroker, atLeast(NUMBER_OF_RUNS_TO_CHECK)).returnLease(lease);
     }
 }

--- a/src/test/java/com/github/ikhoury/consumer/PollingThreadTest.java
+++ b/src/test/java/com/github/ikhoury/consumer/PollingThreadTest.java
@@ -6,11 +6,11 @@ import com.github.ikhoury.lease.LeaseRunner;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.github.ikhoury.util.TimeInterval.SHORT_MILLIS;
 import static org.mockito.Mockito.*;
 
 public class PollingThreadTest {
 
-    private static final int WAIT_TIME_MILLIS = 500;
     private static final int NUMBER_OF_RUNS_TO_CHECK = 50;
 
     private PollingThread pollingThread;
@@ -34,7 +34,7 @@ public class PollingThreadTest {
     @Test
     public void onlyRunsRoutineWhenStarted() {
         pollingThread.start();
-        verify(leaseRunner, timeout(WAIT_TIME_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
+        verify(leaseRunner, timeout(SHORT_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
 
         pollingThread.stop();
         reset(leaseRunner);
@@ -44,7 +44,7 @@ public class PollingThreadTest {
     @Test
     public void returnsLeaseAfterRunningRoutine() {
         pollingThread.start();
-        verify(leaseRunner, timeout(WAIT_TIME_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
+        verify(leaseRunner, timeout(SHORT_MILLIS).atLeast(NUMBER_OF_RUNS_TO_CHECK)).run(lease);
 
         pollingThread.stop();
         verify(leaseBroker, atLeast(NUMBER_OF_RUNS_TO_CHECK)).returnLease(lease);

--- a/src/test/java/com/github/ikhoury/consumer/SubscriptionManagerTest.java
+++ b/src/test/java/com/github/ikhoury/consumer/SubscriptionManagerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static com.github.ikhoury.util.TimeInterval.SHORT_MILLIS;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.*;
@@ -16,7 +17,6 @@ public class SubscriptionManagerTest {
 
     private static final String ITEM = "item";
     private static final String QUEUE = "queue";
-    private static final int VERIFY_TIMEOUT_MILLIS = 500;
 
     private SubscriptionManager manager;
     private WorkSubscription subscription;
@@ -37,8 +37,8 @@ public class SubscriptionManagerTest {
 
     @Test
     public void activatesRegisteredSubscriptions() {
-        verify(poller, timeout(VERIFY_TIMEOUT_MILLIS).atLeastOnce()).pollForSingleItemFrom(QUEUE);
-        verify(worker, timeout(VERIFY_TIMEOUT_MILLIS).atLeastOnce()).processSingleItem(ITEM);
+        verify(poller, timeout(SHORT_MILLIS).atLeastOnce()).pollForSingleItemFrom(QUEUE);
+        verify(worker, timeout(SHORT_MILLIS).atLeastOnce()).processSingleItem(ITEM);
     }
 
     @Test

--- a/src/test/java/com/github/ikhoury/driver/JedisBatchPollerTest.java
+++ b/src/test/java/com/github/ikhoury/driver/JedisBatchPollerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.github.ikhoury.config.JedisConfigBuilder.defaultJedisConfig;
+import static com.github.ikhoury.util.TimeInterval.SHORT_SECOND;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -20,7 +21,6 @@ import static org.junit.Assert.fail;
 public class JedisBatchPollerTest {
 
     private static final String ITEM_QUEUE = JedisBatchPollerTest.class.getCanonicalName() + ":" + "items";
-    private static final int POLL_TIME_IN_SECONDS = 1;
     private static final String SINGLE_ITEM = "My Item";
     private static final String[] MULTIPLE_ITEMS = new String[]{"Item 1", "Item 2", "Item 3"};
 
@@ -38,7 +38,7 @@ public class JedisBatchPollerTest {
         JedisConfig jedisConfig = defaultJedisConfig()
                 .withHost(host)
                 .withPort(port)
-                .withPollTimeoutInSeconds(POLL_TIME_IN_SECONDS)
+                .withPollTimeoutInSeconds(SHORT_SECOND)
                 .build();
         poller = new JedisBatchPoller(jedisConfig);
         redisTestDriver = new Jedis(host, port);

--- a/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
@@ -1,0 +1,74 @@
+package com.github.ikhoury.lease;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+
+public class LeaseBrokerTest {
+
+    private static final int MAX_ALLOWED_LEASES = 3;
+    private static final int TEST_TIMEOUT_MILLIS = 3000;
+    private static final Lease LEASE_TO_RETURN = mock(Lease.class);
+
+    private LeaseBroker broker;
+
+    @Before
+    public void setUp() {
+        broker = new LeaseBroker(MAX_ALLOWED_LEASES);
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MILLIS)
+    public void givesOnlyMaximumAllowedNumberOfLeases() {
+        int leasesOverLimit = 2;
+        int totalRequiredLeases = leasesOverLimit + MAX_ALLOWED_LEASES;
+        CompletableFuture[] threadsWithLeases = new CompletableFuture[totalRequiredLeases];
+
+        for (int i = 0; i < totalRequiredLeases; i++) {
+            threadsWithLeases[i] = CompletableFuture.runAsync(this::acquireALease);
+        }
+
+        CompletableFuture[] expectedThreadsThatGotALease = Arrays.copyOfRange(threadsWithLeases, 0, MAX_ALLOWED_LEASES);
+        CompletableFuture[] expectedThreadsThatAreWaitingForALease = Arrays.copyOfRange(threadsWithLeases, MAX_ALLOWED_LEASES, totalRequiredLeases);
+
+        for (CompletableFuture future : expectedThreadsThatGotALease) {
+            future.join();
+        }
+        for (CompletableFuture future : expectedThreadsThatAreWaitingForALease) {
+            assertThat(future.isDone(), equalTo(false));
+        }
+    }
+
+    @Test(timeout = TEST_TIMEOUT_MILLIS)
+    public void reusesLeaseWhenReturned() {
+        // Acquire all leases
+        for (int i = 0; i < MAX_ALLOWED_LEASES; i++) {
+            acquireALease();
+        }
+
+        // Attempt to acquire one more lease
+        CompletableFuture oneMoreLease = CompletableFuture.runAsync(this::acquireALease);
+        assertThat(oneMoreLease.isDone(), equalTo(false));
+
+        // Reuse returned lease
+        returnALease();
+        oneMoreLease.join();
+    }
+
+    private void acquireALease() {
+        broker.acquireLeaseFor(this::aTask, "task");
+    }
+
+    private void returnALease() {
+        broker.returnLease(LEASE_TO_RETURN);
+    }
+
+    private void aTask() {
+        // do nothing
+    }
+}

--- a/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
+import static com.github.ikhoury.util.TimeInterval.LONG_MILLIS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -14,7 +15,6 @@ import static org.mockito.Mockito.mock;
 public class LeaseBrokerTest {
 
     private static final int MAX_ALLOWED_LEASES = 3;
-    private static final int TEST_TIMEOUT_MILLIS = 3000;
 
     private PollingRoutine pollingRoutine;
     private Lease lease;
@@ -29,7 +29,7 @@ public class LeaseBrokerTest {
         broker = new LeaseBroker(MAX_ALLOWED_LEASES);
     }
 
-    @Test(timeout = TEST_TIMEOUT_MILLIS)
+    @Test(timeout = LONG_MILLIS)
     public void givesOnlyMaximumAllowedNumberOfLeases() {
         int leasesOverLimit = 2;
         int totalRequiredLeases = leasesOverLimit + MAX_ALLOWED_LEASES;
@@ -50,7 +50,7 @@ public class LeaseBrokerTest {
         }
     }
 
-    @Test(timeout = TEST_TIMEOUT_MILLIS)
+    @Test(timeout = LONG_MILLIS)
     public void reusesLeaseWhenReturned() {
         // Acquire all leases
         for (int i = 0; i < MAX_ALLOWED_LEASES; i++) {

--- a/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
@@ -36,7 +36,7 @@ public class LeaseRunnerTest {
 
     @Test
     public void returnsLeaseIfExceptionThrown() {
-        doThrow(RuntimeException.class).when(lease).getTask();
+        when(lease.getTask()).thenThrow(RuntimeException.class);
 
         leaseRunner.run(lease);
 

--- a/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
@@ -1,0 +1,29 @@
+package com.github.ikhoury.lease;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class LeaseRunnerTest {
+
+    private static final int WAIT_FOR_TASK_RUN_MILLIS = 500;
+
+    private Lease lease;
+    private Runnable task;
+
+    @Before
+    public void setUp() {
+        lease = mock(Lease.class);
+        task = mock(Runnable.class);
+
+        when(lease.getTask()).thenReturn(task);
+    }
+
+    @Test
+    public void runsLeaseTaskAsync() {
+        LeaseRunner.run(lease);
+
+        verify(task, timeout(WAIT_FOR_TASK_RUN_MILLIS)).run();
+    }
+}

--- a/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
@@ -3,11 +3,15 @@ package com.github.ikhoury.lease;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.Executors;
+
 import static org.mockito.Mockito.*;
 
 public class LeaseRunnerTest {
 
     private static final int WAIT_FOR_TASK_RUN_MILLIS = 500;
+
+    private LeaseRunner leaseRunner;
 
     private Lease lease;
     private Runnable task;
@@ -18,11 +22,13 @@ public class LeaseRunnerTest {
         task = mock(Runnable.class);
 
         when(lease.getTask()).thenReturn(task);
+
+        leaseRunner = new LeaseRunner(Executors.newSingleThreadExecutor());
     }
 
     @Test
     public void runsLeaseTaskAsync() {
-        LeaseRunner.run(lease);
+        leaseRunner.run(lease);
 
         verify(task, timeout(WAIT_FOR_TASK_RUN_MILLIS)).run();
     }

--- a/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
@@ -5,11 +5,10 @@ import org.junit.Test;
 
 import java.util.concurrent.Executors;
 
+import static com.github.ikhoury.util.TimeInterval.SHORT_MILLIS;
 import static org.mockito.Mockito.*;
 
 public class LeaseRunnerTest {
-
-    private static final int WAIT_FOR_TASK_RUN_MILLIS = 500;
 
     private LeaseRunner leaseRunner;
 
@@ -30,6 +29,6 @@ public class LeaseRunnerTest {
     public void runsLeaseTaskAsync() {
         leaseRunner.run(lease);
 
-        verify(task, timeout(WAIT_FOR_TASK_RUN_MILLIS)).run();
+        verify(task, timeout(SHORT_MILLIS)).run();
     }
 }

--- a/src/test/java/com/github/ikhoury/util/TimeInterval.java
+++ b/src/test/java/com/github/ikhoury/util/TimeInterval.java
@@ -1,0 +1,8 @@
+package com.github.ikhoury.util;
+
+public class TimeInterval {
+    public static final int SHORT_MILLIS = 500;
+    public static final int SHORT_SECOND = 1;
+
+    public static final int LONG_MILLIS = 5000;
+}


### PR DESCRIPTION
We don't want the same polling thread to execute the task at hand. The execution is delegated to a dedicated thread pool. In order to control the data flow and the amount of tasks that can be executed concurrently, the concept of a lease is introduced. The polling thread must acquire a lease from a limit lease pool in order to poll for more tasks. Once tasks complete, their lease is returned to process other outstanding tasks.