### PR TITLE
Remove name property from lease

### DIFF
--- a/src/main/java/com/github/ikhoury/consumer/SubscriptionManager.java
+++ b/src/main/java/com/github/ikhoury/consumer/SubscriptionManager.java
@@ -65,10 +65,11 @@ public class SubscriptionManager {
 
     private void activateSubscription(WorkSubscription subscription) {
         ExecutorService executorService = newFixedThreadPool(leaseConfig.getMaxActiveLeases());
-        LeaseBroker leaseBroker = new LeaseBroker(leaseConfig);
-        LeaseRunner leaseRunner = new LeaseRunner(leaseBroker, executorService);
+        String queue = subscription.getQueue();
+        LeaseBroker leaseBroker = new LeaseBroker(leaseConfig, queue);
+        LeaseRunner leaseRunner = new LeaseRunner(leaseBroker, executorService, queue);
 
-        PollingRoutine routine = new PollingRoutine(pollingConfig, poller, subscription.getQueue());
+        PollingRoutine routine = new PollingRoutine(pollingConfig, poller, queue);
         SubscriptionRunner subscriptionRunner = new SubscriptionRunner(subscription, leaseBroker, leaseRunner, routine);
         subscriptionRunner.start();
 

--- a/src/main/java/com/github/ikhoury/consumer/SubscriptionRunner.java
+++ b/src/main/java/com/github/ikhoury/consumer/SubscriptionRunner.java
@@ -64,7 +64,7 @@ class SubscriptionRunner {
                 List<String> items = routine.doPoll();
 
                 if (!items.isEmpty()) {
-                    Lease lease = leaseBroker.acquireLeaseFor(queue);
+                    Lease lease = leaseBroker.acquireLease();
 
                     if (items.size() == 1) {
                         lease.setTask(() -> processSingleItem(items.get(0)));

--- a/src/main/java/com/github/ikhoury/lease/Lease.java
+++ b/src/main/java/com/github/ikhoury/lease/Lease.java
@@ -2,11 +2,9 @@ package com.github.ikhoury.lease;
 
 public class Lease {
 
-    private final String name;
     private Runnable task;
 
-    public Lease(String name) {
-        this.name = name;
+    public Lease() {
         this.task = () -> {
             // No Op
         };
@@ -18,9 +16,5 @@ public class Lease {
 
     public void setTask(Runnable task) {
         this.task = task;
-    }
-
-    public String getName() {
-        return name;
     }
 }

--- a/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
+++ b/src/main/java/com/github/ikhoury/lease/LeaseBroker.java
@@ -16,24 +16,25 @@ public class LeaseBroker {
 
     private final Semaphore leaseStore;
     private final int maxActiveLeases;
+    private String queue;
 
-    public LeaseBroker(LeaseConfig leaseConfig) {
+    public LeaseBroker(LeaseConfig leaseConfig, String queue) {
         this.maxActiveLeases = leaseConfig.getMaxActiveLeases();
         this.leaseStore = new Semaphore(maxActiveLeases);
+        this.queue = queue;
     }
 
     /**
      * This method guarantees that the caller will return with a lease.
      * If no lease is available then the caller will wait indefinitely for one.
      *
-     * @param name Description for the lease
      * @return A lease
      */
-    public Lease acquireLeaseFor(String name) {
+    public Lease acquireLease() {
         leaseStore.acquireUninterruptibly();
 
-        LOGGER.info("Acquired a lease for {}, {} estimated lease(s) left", name, availableLeaseCount());
-        return new Lease(name);
+        LOGGER.info("Acquired a lease for {}, {} estimated lease(s) left", queue, availableLeaseCount());
+        return new Lease();
     }
 
     /**
@@ -43,7 +44,7 @@ public class LeaseBroker {
      */
     void returnLease(Lease lease) {
         leaseStore.release();
-        LOGGER.info("Released a lease for {}", lease.getName());
+        LOGGER.info("Returning a lease for {}", queue);
     }
 
     int activeLeaseCount() {

--- a/src/test/java/com/github/ikhoury/consumer/SubscriptionRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/consumer/SubscriptionRunnerTest.java
@@ -20,11 +20,8 @@ import static org.mockito.Mockito.*;
 
 public class SubscriptionRunnerTest {
 
-    private static final String WORK_QUEUE = "workQueue";
-
     private SubscriptionRunner subscriptionRunner;
     private PollingRoutine routine;
-    private LeaseRunner leaseRunner;
     private LeaseBroker leaseBroker;
     private Worker singleItemWorker;
     private BatchWorker multipleItemsWorker;
@@ -36,13 +33,12 @@ public class SubscriptionRunnerTest {
         singleItemWorker = mock(Worker.class);
         multipleItemsWorker = mock(BatchWorker.class);
         leaseBroker = mock(LeaseBroker.class);
-        leaseRunner = mock(LeaseRunner.class);
+        LeaseRunner leaseRunner = mock(LeaseRunner.class);
         WorkSubscription subscription = mock(WorkSubscription.class);
-        Lease lease = new Lease(WORK_QUEUE);
+        Lease lease = new Lease();
 
-        when(subscription.getQueue()).thenReturn(WORK_QUEUE);
         when(subscription.getWorkers()).thenReturn(asList(singleItemWorker, multipleItemsWorker));
-        when(leaseBroker.acquireLeaseFor(any())).thenReturn(lease);
+        when(leaseBroker.acquireLease()).thenReturn(lease);
         doAnswer(invocation -> {
             Lease argument = invocation.getArgument(0, Lease.class);
             argument.getTask().run();
@@ -58,7 +54,7 @@ public class SubscriptionRunnerTest {
 
         subscriptionRunner.start();
 
-        verify(leaseBroker, timeout(SHORT_MILLIS).atLeastOnce()).acquireLeaseFor(WORK_QUEUE);
+        verify(leaseBroker, timeout(SHORT_MILLIS).atLeastOnce()).acquireLease();
     }
 
     @Test
@@ -67,7 +63,7 @@ public class SubscriptionRunnerTest {
 
         subscriptionRunner.start();
 
-        verify(leaseBroker, after(SHORT_MILLIS).never()).acquireLeaseFor(WORK_QUEUE);
+        verify(leaseBroker, after(SHORT_MILLIS).never()).acquireLease();
     }
 
     @Test

--- a/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseBrokerTest.java
@@ -26,7 +26,7 @@ public class LeaseBrokerTest {
 
         when(leaseConfig.getMaxActiveLeases()).thenReturn(MAX_ALLOWED_LEASES);
 
-        broker = new LeaseBroker(leaseConfig);
+        broker = new LeaseBroker(leaseConfig, "queue");
     }
 
     @Test(timeout = LONG_MILLIS)
@@ -35,11 +35,11 @@ public class LeaseBrokerTest {
         CompletableFuture[] extraLeases = new CompletableFuture[leasesOverLimit];
 
         for (int i = 0; i < MAX_ALLOWED_LEASES; i++) {
-            broker.acquireLeaseFor("name");
+            broker.acquireLease();
         }
 
         for (int i = 0; i < leasesOverLimit; i++) {
-            extraLeases[i] = CompletableFuture.runAsync(() -> broker.acquireLeaseFor("name"));
+            extraLeases[i] = CompletableFuture.runAsync(() -> broker.acquireLease());
         }
 
         for (CompletableFuture future : extraLeases) {
@@ -51,11 +51,11 @@ public class LeaseBrokerTest {
     public void reusesLeaseWhenReturned() {
         // Acquire all leases
         for (int i = 0; i < MAX_ALLOWED_LEASES; i++) {
-            broker.acquireLeaseFor("name");
+            broker.acquireLease();
         }
 
         // Attempt to acquire one more lease
-        CompletableFuture oneMoreLease = CompletableFuture.runAsync(() -> broker.acquireLeaseFor("name"));
+        CompletableFuture oneMoreLease = CompletableFuture.runAsync(() -> broker.acquireLease());
         assertThat(oneMoreLease.isDone(), equalTo(false));
 
         // Reuse returned lease
@@ -68,7 +68,7 @@ public class LeaseBrokerTest {
         assertThat(broker.activeLeaseCount(), equalTo(0));
         assertThat(broker.availableLeaseCount(), equalTo(MAX_ALLOWED_LEASES));
 
-        broker.acquireLeaseFor("name");
+        broker.acquireLease();
         assertThat(broker.activeLeaseCount(), equalTo(1));
         assertThat(broker.availableLeaseCount(), equalTo(MAX_ALLOWED_LEASES - 1));
 

--- a/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
+++ b/src/test/java/com/github/ikhoury/lease/LeaseRunnerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.*;
 
 public class LeaseRunnerTest {
 
+    private static final String WORK_QUEUE = "queue";
+
     private LeaseRunner leaseRunner;
 
     private Lease lease;
@@ -29,7 +31,7 @@ public class LeaseRunnerTest {
 
         when(lease.getTask()).thenReturn(task);
 
-        leaseRunner = new LeaseRunner(leaseBroker, executorService);
+        leaseRunner = new LeaseRunner(leaseBroker, executorService, WORK_QUEUE);
     }
 
     @Test


### PR DESCRIPTION
Name property in Lease is redundant. The queue name is passed to the LeaseRunner and LeaseBroker constructors.